### PR TITLE
Add: パンくずリストの作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ gem 'aws-sdk-s3'
 gem 'httpclient'
 gem 'dotenv-rails'
 gem 'ransack'
+gem 'gretel'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,9 @@ GEM
     ffi (1.15.5)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    gretel (4.5.0)
+      actionview (>= 5.1, < 7.1)
+      railties (>= 5.1, < 7.1)
     httpclient (2.8.3)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
@@ -349,6 +352,7 @@ DEPENDENCIES
   devise-i18n-views
   dotenv-rails
   factory_bot_rails
+  gretel
   httpclient
   image_processing (~> 1.2)
   importmap-rails

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11716,7 +11716,7 @@ h2 {
 }
 
 .nav-bar-search {
-  align-items: center;
+  display: block;
 }
 
 .nav-bar-search-field {
@@ -11726,10 +11726,18 @@ h2 {
   font-family: "Font Awesome 5 Free";
   font-weight: 900;
   margin: 8px 0;
+  outline: none;
 }
 
 .nav-bar-search-submit {
+  border: none;
+  background-color: transparent;
   color: rgba(255, 255, 255, 0.55);
+  transition: color 0.15s ease-in-out;
+}
+
+.nav-bar-search-submit:hover {
+  color: #ffffff;
 }
 
 .search-area {
@@ -11829,4 +11837,28 @@ h2 {
   width: auto;
   height: 80px;
   margin: auto 0;
+}
+
+.breadcrumbs {
+  margin-bottom: 15px;
+}
+
+.breadcrumbs a {
+  text-decoration: none;
+  color: rgba(255, 255, 255, 0.55);
+  transition: color 0.15s ease-in-out;
+}
+
+.breadcrumbs a:hover {
+  color: #ffffff;
+}
+
+.link-transition {
+  text-decoration: none;
+  color: rgba(255, 255, 255, 0.55);
+  transition: color 0.15s ease-in-out;
+}
+
+.link-transition:hover {
+  color: #ffffff;
 }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,10 +10,10 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
     @game_account_info = @user.game_account_info
     @trn_player_stats = TrackerApiService.fetch_trn_player_stats(@game_account_info)
-    if @trn_player_stats["message"] == "API rate limit exceeded"
-      @trn_player_stats = "Apilimit"
-    elsif @trn_player_stats.nil? || @trn_player_stats.include?("errors")
+    if @trn_player_stats.nil? || @trn_player_stats.include?("errors")
       @trn_player_stats = nil
+    elsif @trn_player_stats["message"] == "API rate limit exceeded"
+      @trn_player_stats = "Apilimit"
     else
       fetch_trn_overall_segment_stats
       fetch_trn_current_season_stats

--- a/app/views/layouts/_login_user_nav.html.erb
+++ b/app/views/layouts/_login_user_nav.html.erb
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" id="mainNav">
   <div class="container px-4">
     <%= link_to image_tag("nav_logo.jpg", class: "nav-logo"), root_path, class: "navbar-brand" %>
-    <%= link_to "ユーザー一覧", users_path %>
+    <%= link_to "ユーザー一覧", users_path, class: "link-transition me-3" %>
     <%= render "shared/nav_bar_user_search_form" %>
     <div class="collapse navbar-collapse" id="navbarResponsive">
         <ul class="navbar-nav ms-auto">

--- a/app/views/layouts/_no_login_user_nav.html.erb
+++ b/app/views/layouts/_no_login_user_nav.html.erb
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" id="mainNav">
   <div class="container px-4">
     <%= link_to image_tag("nav_logo.jpg", class: "nav-logo"), root_path, class: "navbar-brand" %>
-    <%= link_to "ユーザー一覧", users_path %>
+    <%= link_to "ユーザー一覧", users_path, class: "link-transition me-3" %>
     <%= render "shared/nav_bar_user_search_form" %>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
     <div class="collapse navbar-collapse" id="navbarResponsive">

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -1,0 +1,13 @@
+<% case params.values_at(:controller, :action) %>
+<% when ["users", "index"] %>
+  <% breadcrumb :users %>
+<% when ["users", "show"] %>
+  <% breadcrumb :user_show, @user %>
+<% when ["users", "search"] %>
+  <% breadcrumb :search %>
+<% when ["devise/registrations", "new"] %>
+  <% breadcrumb :sign_up %>
+<% when ["devise/sessions", "new"] %>
+  <% breadcrumb :log_in %>
+<% end %>
+<%= breadcrumbs separator: " &rsaquo; " %>

--- a/app/views/shared/_nav_bar_user_search_form.html.erb
+++ b/app/views/shared/_nav_bar_user_search_form.html.erb
@@ -1,6 +1,6 @@
 <%= search_form_for @q, url: search_users_path do |f| %>
   <div class="nav-bar-search">
     <%= f.search_field :name_or_game_account_info_platform_or_game_account_info_gameid_cont, class: "nav-bar-search-field", placeholder: " \uf002 キーワード検索" %>
-    <%= f.submit '検索', class: "btn btn-dark nav-bar-search-submit" %>
+    <%= f.submit '検索', class: "nav-bar-search-submit" %>
   </div>
 <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,5 +1,6 @@
 <header class="bg-gradient header header-mypage">
   <div class="header-container">
+  <%= render "shared/breadcrumbs" %>
     <h2>ユーザー一覧</h2>
     <p>登録ユーザー：<%=@users_result.count %></p>
     <hr class="hr-white">

--- a/app/views/users/search.html.erb
+++ b/app/views/users/search.html.erb
@@ -1,5 +1,6 @@
 <header class="bg-gradient header header-mypage">
   <div class="header-container">
+    <%= render "shared/breadcrumbs" %>
     <h2>ユーザー検索結果</h2>
     <p>検索結果：<%=@users_result.count %></p>
     <hr class="hr-white">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,6 @@
 <header class="bg-gradient header header-mypage">
   <div class="header-container">
+    <%= render "shared/breadcrumbs" %>
     <div class="header-container-first-line">
       <div class="header-mypage-left" >
         <% if @user.avatar.attached? %>
@@ -39,7 +40,7 @@
   </div>
 </header>
 <div class="game-stats-area bg-dark-black">
-  <% if @trn_player_stats = "Apilimit" %>
+  <% if @trn_player_stats == "Apilimit" %>
     <%= render "api_rate_limit" %>
   <% elsif @trn_player_stats.present? %>
     <%= render "overall_stats" %>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,32 @@
+crumb :root do
+  link "Home", root_path
+end
+
+crumb :sign_up do
+  link "新規登録", new_user_registration_path
+  parent :root
+end
+
+crumb :log_in do
+  link "ログイン", new_user_session_path
+  parent :root
+end
+
+crumb :users  do |user|
+  link "ユーザー一覧", users_path
+  parent :root
+end
+
+crumb :user_show do |user|
+  if user.id == current_user.id
+    link "マイページ", user_path(user)
+  else
+    link "#{user.name}", user_path(user)
+  end
+  parent :users
+end
+
+crumb :search do
+  link "ユーザー検索", search_users_path
+  parent :root
+end


### PR DESCRIPTION
## 実装目的
- パンくずリストを作成することによって、使用者が今どの階層にいるかを把握しやすくなる。
- 前のページに戻る際、元のページが何のページか把握しやすくなる。また、パンくずリストから直接戻ることができる。
## 実装内容
- Add: gem "gretel"を使用してパンくずリストを作成
