### PR TITLE
Add: ゲストログイン機能の実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11506,6 +11506,7 @@ h2 {
 }
 
 .bg-dark-black {
+  min-height: 44vh;
   background-color: #16160e;
 }
 

--- a/app/controllers/game_account_info_controller.rb
+++ b/app/controllers/game_account_info_controller.rb
@@ -2,7 +2,11 @@ class GameAccountInfoController < ApplicationController
   before_action :authenticate_user!
 
   def edit
-    @game_account_info = GameAccountInfo.find_or_initialize_by(user_id: current_user.id)
+    if current_user.id == 1
+      redirect_to user_path(current_user.id), alert: "ゲストアカウントにはゲームアカウントを登録できません。"
+    else
+      @game_account_info = GameAccountInfo.find_or_initialize_by(user_id: current_user.id)
+    end
   end
 
   def update

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,9 @@
+class Users::PasswordsController < Devise::PasswordsController
+  before_action :ensure_normal_user, only: :create
+
+  def ensure_normal_user
+    if params[:user][:email].downcase == 'guest@example.com'
+      redirect_to new_user_session_path, alert: 'ゲストユーザーのパスワード再設定はできません。'
+    end
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,10 @@
+class Users::RegistrationsController < Devise::RegistrationsController
+  before_action :ensure_normal_user, only: %i[update destroy]
+
+  def ensure_normal_user
+    if resource.email == "guest@example.com"
+      redirect_to user_path(current_user.id), alert: "ゲストユーザーの更新・削除はできません。"
+    end
+  end
+
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,7 @@
+class Users::SessionsController < Devise::SessionsController
+  def guest_sign_in
+    user = User.guest
+    sign_in user
+    redirect_to root_path, notice: "ゲストユーザーとしてログインしました。"
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,4 @@
 class UsersController < ApplicationController
-  before_action :authenticate_user!
   PERCENTAGE_BASE = 100
 
   def index

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,4 +16,12 @@ class User < ApplicationRecord
   def self.ransackable_associations(_auth_object = nil)
     ["game_account_info"]
   end
+
+  def self.guest
+    find_or_create_by!(email: 'guest@example.com') do |user|
+      user.name = "ゲストアカウント"
+      user.password = SecureRandom.urlsafe_base64
+      user.password_confirmation = user.password
+    end
+  end
 end

--- a/app/views/layouts/_login_user_nav.html.erb
+++ b/app/views/layouts/_login_user_nav.html.erb
@@ -8,7 +8,7 @@
             <li class="nav-item"><a class="nav-link nav-margin-top" href="#about">ApexLegends Statusとは</a></li>
             <p></p>
             <li class="nav-item"><%= link_to "マイページ", user_path(current_user.id), class:"nav-link nav-margin-top" %></li>
-            <li class="nav-item"><%= link_to "ログアウト", destroy_user_session_path, method: :delete, class:"nav-link nav-margin-top" %></li>
+            <li class="nav-item"><%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: "get", turbo_confirm: "ログアウトしますか？" } , class:"nav-link nav-margin-top" %></li>
         </ul>
     </div>
   </div>

--- a/app/views/layouts/_no_login_user_nav.html.erb
+++ b/app/views/layouts/_no_login_user_nav.html.erb
@@ -7,8 +7,8 @@
     <div class="collapse navbar-collapse" id="navbarResponsive">
         <ul class="navbar-nav ms-auto">
             <li class="nav-item"><a class="nav-link nav-margin-top" href="#about">ApexLegends Statusとは</a></li>
-            <li class="nav-item"><%= link_to "Log in", new_user_session_path, class:"nav-link nav-margin-top" %></li>
-            <li class="nav-item"><%= link_to "Sign up", new_user_registration_path, class:"nav-link nav-margin-top" %></li>
+            <li class="nav-item"><%= link_to "ログイン", new_user_session_path, class:"nav-link nav-margin-top" %></li>
+            <li class="nav-item"><%= link_to "新規登録", new_user_registration_path, class:"nav-link nav-margin-top" %></li>
             <li class="nav-item"><%= link_to "ゲストログイン", users_guest_sign_in_path, data: { "turbo-method": :post }, class:"nav-link nav-margin-top"  %></li>
         </ul>
     </div>

--- a/app/views/layouts/_no_login_user_nav.html.erb
+++ b/app/views/layouts/_no_login_user_nav.html.erb
@@ -9,6 +9,7 @@
             <li class="nav-item"><a class="nav-link nav-margin-top" href="#about">ApexLegends Statusとは</a></li>
             <li class="nav-item"><%= link_to "Log in", new_user_session_path, class:"nav-link nav-margin-top" %></li>
             <li class="nav-item"><%= link_to "Sign up", new_user_registration_path, class:"nav-link nav-margin-top" %></li>
+            <li class="nav-item"><%= link_to "ゲストログイン", users_guest_sign_in_path, data: { "turbo-method": :post }, class:"nav-link nav-margin-top"  %></li>
         </ul>
     </div>
   </div>

--- a/app/views/top/_login_user_top.html.erb
+++ b/app/views/top/_login_user_top.html.erb
@@ -4,7 +4,6 @@
       <h1 class="fw-bolder">ApexLegends Statuにようこそ</h1>
       <p class="lead">このサイトではあなたの戦績を表示します</p>
       <%= link_to "マイページで戦績を確認する", user_path(current_user.id), class:"btn btn-lg btn-dark btn-border-color-white" %>
-      <%= link_to "ログインはこちら", new_user_session_path, class:"btn btn-lg btn-dark btn-border-color-white" %>
     </div>
   </div>
 </header>

--- a/app/views/users/_guest_account.html.erb
+++ b/app/views/users/_guest_account.html.erb
@@ -1,0 +1,12 @@
+<div class="trn-failed-stats-area">
+  <div class="trn-failed-stats-container bg-gray">
+    <h2>ゲストアカウントでは戦績は表示できません。</h2>
+    <hr class="hr-white">
+    <div class="trn-failed-stats-body">
+      <div class="trn-error-check-list">
+        <p>Tracker Networkと連携したサービスを利用するには？</p>
+        <p>・全てのサービスを利用するには<%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: "get", turbo_confirm: "ログアウトしますか？" } %>後に、ログインまたはアカウントを作成してください。</p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/users/_guest_account.html.erb
+++ b/app/views/users/_guest_account.html.erb
@@ -5,7 +5,11 @@
     <div class="trn-failed-stats-body">
       <div class="trn-error-check-list">
         <p>Tracker Networkと連携したサービスを利用するには？</p>
-        <p>・全てのサービスを利用するには<%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: "get", turbo_confirm: "ログアウトしますか？" } %>後に、ログインまたはアカウントを作成してください。</p>
+        <% if user_signed_in? %>
+          <p>・全てのサービスを利用するには<%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: "get", turbo_confirm: "ログアウトしますか？" } %>後に、ログインまたはアカウントを作成してください。</p>
+        <% else %>
+          <p>・全てのサービスを利用するにはログアウト後に、ログインまたはアカウントを作成してください。</p>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -22,7 +22,7 @@
           <% end %>
         </div>
       </div>
-      <% if @user.id == current_user.id %>
+      <% if user_signed_in? && @user.id == current_user.id %>
         <div class="header-mypage-right">
           <div class="profiel-edit-btn">
             <%= link_to "プロフィールを編集する", edit_user_registration_path, class: "btn-dark btn-lg btn btn-border-color-white wd-300" %>
@@ -45,6 +45,8 @@
   <% elsif @trn_player_stats.present? %>
     <%= render "overall_stats" %>
     <%= render "legend_stats_card" %>
+  <% elsif @user.id == 1 %>
+    <%= render "guest_account"%>
   <% else %>
     <%= render "no_game_account_info" %>
   <% end %>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -18,7 +18,7 @@ crumb :users  do |user|
 end
 
 crumb :user_show do |user|
-  if user.id == current_user.id
+  if user_signed_in? && user.id == current_user.id
     link "マイページ", user_path(user)
   else
     link "#{user.name}", user_path(user)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,11 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: {
+    registrations: 'users/registrations',
+    passwords: 'users/passwords'
+  }
+  devise_scope :user do
+    post 'users/guest_sign_in', to: 'users/sessions#guest_sign_in'
+  end
   root 'top#index'
   resources :users, only: %i[index show] do
     collection do


### PR DESCRIPTION
## 実装目的
- ゲストログイン機能を実装することによって、新規登録の手間を省きつつ、簡単にアプリを使用することができる。
## 実装内容
- Add: ゲストログイン機能の実装
  ゲストアカウントではユーザー一覧やユーザー検索機能が使用できます。プロフィール編集やTracker Networkと連携した機能は使用できません。
- Add: ゲストアカウントでログイン時のマイページのパーシャルを実装。
## 参考記事
簡単ログイン・ゲストログイン機能の実装方法（ポートフォリオ用）[https://qiita.com/take18k_tech/items/35f9b5883f5be4c6e104](url)