### PR TITLE
Update: ユーザー退会機能(物理削除)を実装

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,6 +11,13 @@ class UsersController < ApplicationController
     game_account_check
   end
 
+  def destroy
+    @user = User.find(params[:id])
+    @user.destroy
+    flash[:notice] = 'ユーザーを削除しました。'
+    redirect_to :root #削除に成功すればrootページに戻る
+  end
+
   private
 
   def game_account_check
@@ -31,6 +38,7 @@ class UsersController < ApplicationController
   end
 
   def fetch_trn_overall_stats
+    binding.pry
     @trn_overall_stats_name = ["level", "kills", "damage", "matchesPlayed", "wins", "killsAsKillLeader"]
     @trn_overall_stats_name.each do |segment|
       value = TrackerApiService.overall_stat_value(@trn_player_stats, segment)

--- a/app/views/layouts/_login_user_nav.html.erb
+++ b/app/views/layouts/_login_user_nav.html.erb
@@ -12,6 +12,7 @@
             <li class="nav-item"><%= link_to "プロフィール編集", edit_user_registration_path(current_user.id), class:"nav-link nav-margin-top" %></li>
             <li class="nav-item"><%= link_to "ゲームアカウント登録・編集", edit_game_account_info_path(current_user.id), class:"nav-link nav-margin-top" %></li>
             <li class="nav-item"><%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: "get", turbo_confirm: "ログアウトしますか？" } , class:"nav-link nav-margin-top" %></li>
+            <li class="nav-item"><%= link_to "退会",user_path(current_user.id), data: { turbo_method: "delete", turbo_confirm: "【確認】アカウントを削除しますか？" } , class:"nav-link nav-margin-top"%></li>
         </ul>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
 
   root 'top#index'
 
-  resources :users, only: %i[index show] do
+  resources :users, only: %i[index show destroy] do
     collection do
       get 'search'
     end


### PR DESCRIPTION
## 実装目的
- ユーザーが任意で削除できる機能の実装により、ユーザーの個人情報を保護。
- ユーザー削除時にゲームアカウント情報や試合履歴も削除することでデータベースの負荷を軽減。
## 実装内容
- ユーザーコントローラーにdestroyアクションを実装。
ユーザー削除時に関連するゲームアカウント、試合履歴も削除。