### PR TITLE
Fix: ゲームアカウントが間違っている場合に部分テンプレートが表示されない問題を修正 #13

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11853,6 +11853,7 @@ h2 {
 
 .legend-stats-title h2 {
   text-align: center;
+  margin-top: 1.5rem;
 }
 
 @media (max-width: 768px) {

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,7 +25,7 @@ class UsersController < ApplicationController
       @trn_player_stats = "No account"
     else
       @trn_player_stats = TrackerApiService.fetch_trn_player_stats(@game_account_info)
-      fetch_trn_player_stats if @trn_player_stats.include?("data")
+      @trn_player_stats.include?("data") ? fetch_trn_player_stats : @trn_player_stats = "No account"
     end
   end
 
@@ -38,7 +38,6 @@ class UsersController < ApplicationController
   end
 
   def fetch_trn_overall_stats
-    binding.pry
     @trn_overall_stats_name = ["level", "kills", "damage", "matchesPlayed", "wins", "killsAsKillLeader"]
     @trn_overall_stats_name.each do |segment|
       value = TrackerApiService.overall_stat_value(@trn_player_stats, segment)


### PR DESCRIPTION
## 実装内容
- user contorollerのgame_account_checkメソッドにてゲームアカウントが入力されているが、アカウント情報を取得できなかった際の条件分岐を追加。