### PR TITLE
Update: 現在のランクによるユーザー検索機能の追加 #17

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -73,18 +73,19 @@ class UsersController < ApplicationController
     @trn_legend_stats_name = ["kills", "damage", "wins", "matchesPlayed", "killsAsKillLeader"]
   end
 
-  def set_trn_instance_variables(prefix, segment, value, rank, percentile)
-    instance_variable_set("@trn_#{prefix}_#{segment}_value", value)
-    instance_variable_set("@trn_#{prefix}_#{segment}_rank", rank)
-    instance_variable_set("@trn_#{prefix}_#{segment}_percentile", percentile)
-  end
-
   def current_rank
     @trn_rank_name = @trn_player_stats.dig("data", "segments", 0, "stats", "rankScore", "metadata", "rankName")
+    @user.game_account_info.update(current_rank:@trn_rank_name)
     value = nil
     rank = TrackerApiService.overall_stat_rank(@trn_player_stats, "rankScore")
     percentile = TrackerApiService.overall_stat_percentile(@trn_player_stats, "rankScore")
     set_trn_instance_variables("rank", "point", value, rank, percentile)
+  end
+
+  def set_trn_instance_variables(prefix, segment, value, rank, percentile)
+    instance_variable_set("@trn_#{prefix}_#{segment}_value", value)
+    instance_variable_set("@trn_#{prefix}_#{segment}_rank", rank)
+    instance_variable_set("@trn_#{prefix}_#{segment}_percentile", percentile)
   end
 
   def value_check(value1, value2)

--- a/app/models/game_account_info.rb
+++ b/app/models/game_account_info.rb
@@ -4,7 +4,7 @@ class GameAccountInfo < ApplicationRecord
   validates :gameid, presence: true
 
   def self.ransackable_attributes(_auth_object = nil)
-    ["platform", "gameid", "rank"]
+    ["platform", "gameid", "current_rank"]
   end
 
   def self.ransackable_associations(_auth_object = nil)

--- a/app/views/shared/_user_search_form.html.erb
+++ b/app/views/shared/_user_search_form.html.erb
@@ -18,40 +18,40 @@
     </div>
     <div class="main-form">
       <div class="main-form-left">
-        <%= f.label :game_account_info_rank_eq, "現在のランク"  %>
+        <%= f.label :game_account_info_current_rank_cont, "現在のランク"  %>
       </div>
       <div class="main-form-right">
         <div class="main-form-checkbox">
           <label>
-            <%= f.check_box :game_account_info_rank_eq_any, { multiple: true }, "predator", "" %>
+            <%= f.check_box :game_account_info_current_rank_cont_any, { multiple: true }, "Predator", "" %>
             <span>プレデター</span>
           </label>
           <label>
-            <%= f.check_box :game_account_info_rank_eq_any, { multiple: true }, "master", "" %>
+            <%= f.check_box :game_account_info_current_rank_cont_any, { multiple: true }, "Master", "" %>
             <span>マスター</span>
           </label>
           <label>
-            <%= f.check_box :game_account_info_rank_eq_any, { multiple: true }, "diamond", "" %>
+            <%= f.check_box :game_account_info_current_rank_cont_any, { multiple: true }, "Diamond", "" %>
             <span>ダイヤモンド</span>
           </label>
           <label>
-            <%= f.check_box :game_account_info_rank_eq_any, { multiple: true }, "platinam", "" %>
+            <%= f.check_box :game_account_info_current_rank_cont_any, { multiple: true }, "Platinum", "" %>
             <span>プラチナ</span>
           </label>
           <label>
-            <%= f.check_box :game_account_info_rank_eq_any, { multiple: true }, "gold", "" %>
+            <%= f.check_box :game_account_info_current_rank_cont_any, { multiple: true }, "Gold", "" %>
             <span>ゴールド</span>
           </label>
           <label>
-            <%= f.check_box :game_account_info_rank_eq_any, { multiple: true }, "silver", "" %>
+            <%= f.check_box :game_account_info_current_rank_cont_any, { multiple: true }, "Silver", "" %>
             <span>シルバー</span>
           </label>
           <label>
-            <%= f.check_box :game_account_info_rank_eq_any, { multiple: true }, "bronze", "" %>
+            <%= f.check_box :game_account_info_current_rank_cont_any, { multiple: true }, "Bronze", "" %>
             <span>ブロンズ</span>
           </label>
           <label>
-            <%= f.check_box :game_account_info_rank_eq_any, { multiple: true }, "rookie", "" %>
+            <%= f.check_box :game_account_info_current_rank_cont_any, { multiple: true }, "Rookie", "" %>
             <span>ルーキー</span>
           </label>
         </div>

--- a/db/migrate/20230830112610_add_current_rank_to_game_account_info.rb
+++ b/db/migrate/20230830112610_add_current_rank_to_game_account_info.rb
@@ -1,0 +1,5 @@
+class AddCurrentRankToGameAccountInfo < ActiveRecord::Migration[7.0]
+  def change
+    add_column :game_account_infos, :current_rank, :string
+  end
+end

--- a/db/migrate/20230830112756_remove_rank_from_game_account_info.rb
+++ b/db/migrate/20230830112756_remove_rank_from_game_account_info.rb
@@ -1,0 +1,5 @@
+class RemoveRankFromGameAccountInfo < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :game_account_infos, :rank, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_30_094731) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_30_112756) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -53,7 +53,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_30_094731) do
     t.integer "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "rank"
+    t.string "current_rank"
     t.index ["user_id"], name: "index_game_account_infos_on_user_id"
   end
 


### PR DESCRIPTION
## 実装目的
- 特定のランクに属するユーザーを検索しやすくなる。
## 実装内容
- Userコントローラーに現在のランクをGameAccountInfoモデルのcurrent_rankに保存する機能を追加。
- ransackを使用し、チェックボックスに該当するランク区分ユーザーの絞り込み機能の追加。