### PR TITLE
Add: Rspecの追加実装 #19

### DIFF
--- a/app/views/users/_overall_stats.html.erb
+++ b/app/views/users/_overall_stats.html.erb
@@ -14,12 +14,12 @@
       <div class="overall-stat">
         <span class="name">Season<%= @trn_current_season %>キル数</span>
         <span class="value"><%= @trn_currentseason_Kills_value %></span>
-        <span class="rank"><%= @trn_currentseason_Kills_rank %> - Top<%= @trn_currentseason_Kills_percentile %>%</span>
+        <span class="rank"><%= @trn_currentseason_Kills_rank %> - Top<%= @trn_currentseason_Kills_percentile %></span>
       </div>
       <div class="overall-stat">
         <span class="name">Season<%= @trn_current_season %>勝利数</span>
         <span class="value"><%= @trn_currentseason_Wins_value %></span>
-        <span class="rank"><%= @trn_currentseason_Wins_rank %> - Top<%= @trn_currentseason_Wins_percentile %>%</span>
+        <span class="rank"><%= @trn_currentseason_Wins_rank %> - Top<%= @trn_currentseason_Wins_percentile %></span>
       </div>
       <div class="overall-stat">
         <span class="name">1試合での平均キル数</span>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -38,7 +38,7 @@ end
 
 crumb :user_match_record do |user|
   link "試合履歴", user_tracker_match_records_path(user)
-  parent :users
+  parent :user_show, user
 end
 
 crumb :search do
@@ -58,5 +58,5 @@ end
 
 crumb :complete do
   link "送信完了", complete_path
-  parent :root
+  parent :contact
 end

--- a/spec/models/game_account_info_spec.rb
+++ b/spec/models/game_account_info_spec.rb
@@ -1,4 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe GameAccountInfo, type: :model do
+  let(:user) { FactoryBot.build(:user) }
+  let(:game_account_info) { FactoryBot.build(:game_account_info, user: user) }
+
+  it "プラットフォーム、ゲームIDがある場合、有効である事" do
+    expect(game_account_info).to be_valid
+  end
+
+  it "プラットフォームがない場合、バリデーションエラーを返す事" do
+    game_account_info.platform = nil
+    expect(game_account_info).to_not be_valid
+  end
+
+  it "ゲームIDがない場合、バリデーションエラーを返す事" do
+    game_account_info.gameid = nil
+    expect(game_account_info).to_not be_valid
+  end
 end

--- a/spec/models/tracker_api_service_spec.rb
+++ b/spec/models/tracker_api_service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe TrackerApiService, type: :model do
-  let(:overall_data) do {
+  let(:overall_data) do{
       "data" => {
         "metadata" => {"currentSeason" => 10},
         "segments" =>[

--- a/spec/requests/tracker_api_service_spec.rb
+++ b/spec/requests/tracker_api_service_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe TrackerApiService, type: :request do
+  let(:user) { FactoryBot.create(:user) }
+  let(:game_account_info) { FactoryBot.create(:game_account_info, user: user) }
+  let(:no_game_account_info) { FactoryBot.create(:no_game_account_info, user: user) }
+
+  describe "API通信を行う時" do
+    context "ゲームアカウントが存在する時" do
+      it "アカウント情報が返ってくること" do
+        result = TrackerApiService.fetch_trn_player_stats(game_account_info)
+        expect(result).to include("data")
+      end
+    end
+
+    context "ゲームアカウントが見つからない時" do
+      it "No accountを返す事" do
+        result = TrackerApiService.fetch_trn_player_stats(no_game_account_info)
+        expect(result).to eq "No account"
+      end
+    end
+
+    context "APIリクエスト数の上限に達した時" do
+      it "Apilimitを返す事" do
+        allow(TrackerApiService).to receive(:fetch_trn_player_stats).and_return("Apilimit")
+        result = TrackerApiService.fetch_trn_player_stats(game_account_info)
+        expect(result).to eq "Apilimit"
+      end
+    end
+  end
+end

--- a/spec/requests/tracker_match_records_spec.rb
+++ b/spec/requests/tracker_match_records_spec.rb
@@ -3,6 +3,31 @@ require 'rails_helper'
 RSpec.describe "Users", type: :request do
   let(:user) { FactoryBot.create(:user) }
   let(:game_account_info) { FactoryBot.create(:game_account_info, user: user) }
+  let(:no_game_account_info) { FactoryBot.create(:no_game_account_info, user: user) }
+
+  describe "API通信を行う時" do
+    context "ゲームアカウントが存在する時" do
+      it "アカウント情報が返ってくること" do
+        result = TrackerMatchRecord.fetch_trn_match_history(game_account_info)
+        expect(result).to include("data")
+      end
+    end
+
+    context "ゲームアカウントが見つからない時" do
+      it "No accountを返す事" do
+        result = TrackerMatchRecord.fetch_trn_match_history(no_game_account_info)
+        expect(result).to eq "No account"
+      end
+    end
+
+    context "APIリクエスト数の上限に達した時" do
+      it "Apilimitを返す事" do
+        allow(TrackerMatchRecord).to receive(:fetch_trn_match_history).and_return("Apilimit")
+        result = TrackerMatchRecord.fetch_trn_match_history(game_account_info)
+        expect(result).to eq "Apilimit"
+      end
+    end
+  end
 
   describe "GET/user_tracker_match_records" do
     before do

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe "Users", type: :request do
       before do
         sign_in user
         game_account_info
+        allow(TrackerApiService).to receive(:fetch_trn_player_stats).and_return("Apilimit")
         get user_path(user.id)
       end
 
@@ -64,6 +65,7 @@ RSpec.describe "Users", type: :request do
     context "ゲームアカウントを登録していない時" do
       before do
         sign_in user
+        allow(TrackerApiService).to receive(:fetch_trn_player_stats).and_return("No account")
         get user_path(user.id)
       end
 
@@ -80,6 +82,7 @@ RSpec.describe "Users", type: :request do
       before do
         sign_in user
         no_game_account_info
+        allow(TrackerApiService).to receive(:fetch_trn_player_stats).and_return("No account")
         get user_path(user.id)
       end
 

--- a/spec/system/breadcrumbs_spec.rb
+++ b/spec/system/breadcrumbs_spec.rb
@@ -1,0 +1,168 @@
+require 'rails_helper'
+
+RSpec.describe "Breadcrumbs", type: :system do
+  let(:user) { FactoryBot.create(:user) }
+  let(:guest_user) { FactoryBot.create(:guest_user) }
+  let(:game_account_info) { FactoryBot.create(:game_account_info, user: user) }
+
+  before do
+    guest_user
+    user
+  end
+
+  describe "新規登録画面に遷移した時" do
+    it "Home>新規登録と表示される事" do
+      visit new_user_registration_path
+      within(".breadcrumbs") do
+        expect(page).to have_content "Home"
+        expect(page).to have_content "新規登録"
+      end
+    end
+  end
+
+  describe "ログイン画面に遷移した時" do
+    it "Home>ログインと表示される事" do
+      visit new_user_session_path
+      within(".breadcrumbs") do
+        expect(page).to have_content "Home"
+        expect(page).to have_content "ログイン"
+      end
+    end
+  end
+
+  describe "ユーザー一覧画面に遷移した時" do
+    it "Home>ユーザー一覧と表示される事" do
+      visit users_path
+      within(".breadcrumbs") do
+        expect(page).to have_content "Home"
+        expect(page).to have_content "ユーザー一覧"
+      end
+    end
+  end
+
+  describe "ユーザー検索画面に遷移した時" do
+    it "Home>ユーザー検索と表示される事" do
+      visit search_users_path
+      within(".breadcrumbs") do
+        expect(page).to have_content "Home"
+        expect(page).to have_content "ユーザー検索"
+      end
+    end
+  end
+
+  describe "ユーザー詳細画面に遷移した時" do
+    context "マイページの時" do
+      it "Home>ユーザー一覧>マイページと表示される事" do
+        sign_in user
+        visit user_path(user)
+        within(".breadcrumbs") do
+          expect(page).to have_content "Home"
+          expect(page).to have_content "ユーザー一覧"
+          expect(page).to have_content "マイページ"
+        end
+      end
+    end
+    context "他のユーザー詳細ページの時" do
+      it "Home>ユーザー一覧>ユーザー名と表示される事" do
+        visit user_path(user)
+        within(".breadcrumbs") do
+          expect(page).to have_content "Home"
+          expect(page).to have_content "ユーザー一覧"
+          expect(page).to have_content user.name
+        end
+      end
+    end
+  end
+
+  describe "アカウント編集画面に遷移した時" do
+    it "Home>ユーザー一覧>マイページ>アカウント編集と表示される事" do
+      sign_in user
+      visit edit_user_registration_path(user)
+      within(".breadcrumbs") do
+        expect(page).to have_content "Home"
+        expect(page).to have_content "ユーザー一覧"
+        expect(page).to have_content "マイページ"
+        expect(page).to have_content "アカウント編集"
+      end
+    end
+  end
+
+  describe "ゲームアカウント登録・編集画面に遷移した時" do
+    it "Home>ユーザー一覧>マイページ>ゲームアカウント登録・編集と表示される事" do
+      sign_in user
+      visit edit_game_account_info_path(user)
+      within(".breadcrumbs") do
+        expect(page).to have_content "Home"
+        expect(page).to have_content "ユーザー一覧"
+        expect(page).to have_content "マイページ"
+        expect(page).to have_content "ゲームアカウント登録・編集"
+      end
+    end
+  end
+
+  describe "試合履歴画面に遷移した時" do
+    context "ログインユーザーの時" do
+      it "Home>ユーザー一覧>マイページ>試合履歴と表示される事" do
+        sign_in user
+        visit user_tracker_match_records_path(user)
+        within(".breadcrumbs") do
+          expect(page).to have_content "Home"
+          expect(page).to have_content "ユーザー一覧"
+          expect(page).to have_content "マイページ"
+          expect(page).to have_content "試合履歴"
+        end
+      end
+    end
+
+    context "他のユーザーの時" do
+      it "Home>ユーザー一覧>ユーザー名>試合履歴と表示される事" do
+        visit user_tracker_match_records_path(user)
+        within(".breadcrumbs") do
+          expect(page).to have_content "Home"
+          expect(page).to have_content "ユーザー一覧"
+          expect(page).to have_content user.name
+          expect(page).to have_content "試合履歴"
+        end
+      end
+    end
+  end
+
+  describe "お問い合わせ画面に遷移した時" do
+    it "Home>お問い合わせと表示される事" do
+      visit new_contact_path
+      within(".breadcrumbs") do
+        expect(page).to have_content "Home"
+        expect(page).to have_content "お問い合わせ"
+      end
+    end
+  end
+
+  describe "お問い合わせ確認画面に遷移した時" do
+    it "Home>お問い合わせ>確認画面と表示される事" do
+      visit new_contact_path
+      fill_in "お名前", with: "テストユーザー"
+      fill_in "お問い合わせ内容", with: "テスト"
+      click_button "入力内容確認"
+      within(".breadcrumbs") do
+        expect(page).to have_content "Home"
+        expect(page).to have_content "お問い合わせ"
+        expect(page).to have_content "確認画面"
+      end
+    end
+  end
+
+  describe "お問い合わせ送信完了画面に遷移した時" do
+    it "Home>お問い合わせ>送信完了と表示される事" do
+      visit new_contact_path
+      fill_in "お名前", with: "テストユーザー"
+      fill_in "お問い合わせ内容", with: "テスト"
+      click_button "入力内容確認"
+      click_button "送信"
+      within(".breadcrumbs") do
+        expect(page).to have_content "Home"
+        expect(page).to have_content "お問い合わせ"
+        expect(page).to have_content "送信完了"
+      end
+    end
+  end
+end

--- a/spec/system/contact_spec.rb
+++ b/spec/system/contact_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+
+RSpec.describe Contact, type: :system do
+  let(:contact) { FactoryBot.create(:contact) }
+
+  describe "お問い合わせフォーム" do
+    before do
+      contact
+      visit new_contact_path
+    end
+
+    describe "お問い合わせフォームに遷移した時" do
+      context "フォームの入力値が正常な時" do
+        it "確認画面に遷移する事" do
+          fill_in "お名前", with: contact.name
+          fill_in "メールアドレス", with: contact.email
+          fill_in "お問い合わせ内容", with: contact.message
+          click_button "入力内容確認"
+          expect(current_path).to eq confirm_path
+        end
+      end
+
+      context "お名前が未入力の時" do
+        it "名前を入力してくださいと表示される事" do
+          fill_in "お名前", with: ""
+          fill_in "メールアドレス", with: contact.email
+          fill_in "お問い合わせ内容", with: contact.message
+          click_button "入力内容確認"
+          expect(page).to have_content "名前を入力してください"
+          expect(current_path).to eq new_contact_path
+        end
+      end
+
+      context "お問い合わせ内容が未入力の時" do
+        it "お問い合わせ内容を入力してくださいと表示される事" do
+          fill_in "お名前", with: contact.name
+          fill_in "メールアドレス", with: contact.email
+          fill_in "お問い合わせ内容", with: ""
+          click_button "入力内容確認"
+          expect(page).to have_content "お問い合わせ内容を入力してください"
+          expect(current_path).to eq new_contact_path
+        end
+      end
+    end
+
+    describe "確認画面に遷移した時" do
+      context "全てのフォームに入力されている時" do
+        it "入力内容が表示される事" do
+          fill_in "お名前", with: contact.name
+          fill_in "メールアドレス", with: contact.email
+          fill_in "お問い合わせ内容", with: contact.message
+          click_button "入力内容確認"
+          expect(page.all(".main-form-right")[0]).to have_content contact.name
+          expect(page.all(".main-form-right")[1]).to have_content contact.email
+          expect(page.all(".main-form-right")[2]).to have_content contact.message
+          expect(current_path).to eq confirm_path
+        end
+      end
+
+      context "メールアドレスが未入力の場合" do
+        it "入力内容が表示され、メールアドレスは未入力となる事" do
+          fill_in "お名前", with: contact.name
+          fill_in "メールアドレス", with: ""
+          fill_in "お問い合わせ内容", with: contact.message
+          click_button "入力内容確認"
+          expect(page.all(".main-form-right")[0]).to have_content contact.name
+          expect(page.all(".main-form-right")[1]).to have_content "未入力"
+          expect(page.all(".main-form-right")[2]).to have_content contact.message
+          expect(current_path).to eq confirm_path
+        end
+      end
+
+      context "送信ボタンを押した時" do
+        it "送信完了画面に遷移する事" do
+          fill_in "お名前", with: contact.name
+          fill_in "メールアドレス", with: contact.email
+          fill_in "お問い合わせ内容", with: contact.message
+          click_button "入力内容確認"
+          click_button "送信"
+          expect(page).to have_content "送信完了"
+          expect(current_path).to eq complete_path
+        end
+      end
+
+      context "入力画面に戻るボタンを押した時" do
+        it "お問い合わせフォームに遷移する事" do
+          fill_in "お名前", with: contact.name
+          fill_in "メールアドレス", with: contact.email
+          fill_in "お問い合わせ内容", with: contact.message
+          click_button "入力内容確認"
+          click_button "入力画面に戻る"
+          expect(current_path).to eq new_contact_path
+        end
+
+        it "入力した内容が表示されていること" do
+          fill_in "お名前", with: contact.name
+          fill_in "メールアドレス", with: contact.email
+          fill_in "お問い合わせ内容", with: contact.message
+          click_button "入力内容確認"
+          click_button "入力画面に戻る"
+          expect(page).to have_field "お名前", with: contact.name
+          expect(page).to have_field "メールアドレス", with: contact.email
+          expect(page).to have_field "お問い合わせ内容", with: contact.message
+        end
+      end
+    end
+  end
+end

--- a/spec/system/ransack_spec.rb
+++ b/spec/system/ransack_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe "ransack", type: :system do
   let(:steam_game_account_info) { FactoryBot.create(:steam_game_account_info, user: user2 ) }
 
   before do
+    guest_user
     user
     user2
-    guest_user
     game_account_info
     steam_game_account_info
   end

--- a/spec/system/tracker_api_service_spec.rb
+++ b/spec/system/tracker_api_service_spec.rb
@@ -223,6 +223,7 @@ RSpec.describe TrackerApiService, type: :system do
 
     context "ゲームアカウントが存在しない時" do
       it "戦績が取得できない事" do
+        binding.pry
         no_game_account_info
         visit user_path(user.id)
         expect(page).to have_selector(".trn-failed-stats-container h2", text: "戦績を取得できませんでした")

--- a/spec/system/tracker_api_service_spec.rb
+++ b/spec/system/tracker_api_service_spec.rb
@@ -5,6 +5,51 @@ RSpec.describe TrackerApiService, type: :system do
   let(:guest_user) { FactoryBot.create(:guest_user) }
   let(:game_account_info) { FactoryBot.create(:game_account_info, user: user) }
   let(:no_game_account_info) { FactoryBot.create(:no_game_account_info, user: user) }
+  let(:tracker_api_service) do
+    {
+      "data" => {
+        "metadata" => { "currentSeason" => 10 },
+        "segments" => [
+          {
+            "stats" => {
+              "level" => { "rank" => 25233, "percentile" => 99.3, "value" => 1557.0 },
+              "kills" => { "rank" => 3659, "percentile" => 99.9, "value" => 45350.0 },
+              "killsPerMatch" => { "rank" => nil, "percentile" => 97.4, "value" => 3.96 },
+              "killsAsKillLeader" => { "rank" => nil, "percentile" => 99.9, "value" => 3383.0 },
+              "damage" => { "rank" => 2190, "percentile" => 99.9, "value" => 12892834.0 },
+              "matchesPlayed" => { "rank" => nil, "percentile" => 99.3, "value" => 8916.0 },
+              "rankScore" => { "rank" => 1008, "percentile" => 99.8, "metadata" => { "rankName" => "Master" }, "value" => 33770.0 },
+              "season10Kills" => { "rank" => nil, "percentile" => 99.1, "value" => 4122.0 },
+              "season10Wins" => { "rank" => nil, "percentile" => nil, "value" => nil },
+              "wins" => { "rank" => 4285, "percentile" => 99.6, "value" => 1599.0 }
+            }
+          },
+          {
+            "type" => "legend",
+            "metadata" => { "name" => "Wraith" },
+            "stats" => {
+              "kills" => { "rank" => 2433, "percentile" => 99.0, "value" => 23996.0 },
+              "killsAsKillLeader" => { "rank" => nil, "percentile" => 91.9, "value" => 965.0 },
+              "damage" => { "rank" => 2000, "percentile" => 100.0, "value" => 7025561.0 },
+              "matchesPlayed" => { "rank" => nil, "percentile" => 99.5, "value" => 7751.0 },
+              "wins" => { "rank" => nil, "percentile" => 99.0, "value" => 894.0 }
+            }
+          },
+          {
+            "type" => "legend",
+            "metadata" => { "name" => "Horizon" },
+            "stats" => {
+              "kills" => { "rank" => 10000, "percentile" => 99.1, "value" => 6000.0 },
+              "killsAsKillLeader" => { "rank" => nil, "percentile" => 99.9, "value" => 3830.0 },
+              "damage" => { "rank" => 14324, "percentile" => 100.0, "value" => 1203407.0 },
+              "matchesPlayed" => { "rank" => nil, "percentile" => 99.5, "value" => 10003.0 },
+              "wins" => { "rank" => 42990, "percentile" => 96.9, "value" => 492.0 }
+            }
+          }
+        ]
+      }
+    }
+  end
 
   before do
     guest_user
@@ -20,11 +65,159 @@ RSpec.describe TrackerApiService, type: :system do
 
   describe "ユーザー詳細ページ" do
     context "ゲームアカウントが存在する時" do
-      it "総合戦績が表示される事" do
+      before do
         game_account_info
+        allow(TrackerApiService).to receive(:fetch_trn_player_stats).and_return(tracker_api_service)
         visit user_path(user.id)
-        expect(page).to have_selector(".overall-title p, 総合戦績")
-        expect(page).to have_selector(".legend-stats-title h2, レジェンドステータス")
+      end
+
+      context "総合戦績" do
+        it "レベルが表示される事" do
+          within ".overall-record-area" do
+            expect(page).to have_selector(".overall-stat .name", text: "Level")
+            expect(page).to have_selector(".overall-stat .value", text: "1,557")
+            expect(page).to have_selector(".overall-stat .rank", text: "25,233 - Top0.7%")
+          end
+        end
+
+        it "キル数が表示される事" do
+          within ".overall-record-area" do
+            expect(page).to have_selector(".overall-stat .name", text: "Kills")
+            expect(page).to have_selector(".overall-stat .value", text: "45,350")
+            expect(page).to have_selector(".overall-stat .rank", text: "3,659 - Top0.1%")
+          end
+        end
+
+        it "ダメージ数が表示される事" do
+          within ".overall-record-area" do
+            expect(page).to have_selector(".overall-stat .name", text: "Damage")
+            expect(page).to have_selector(".overall-stat .value", text: "12,892,834")
+            expect(page).to have_selector(".overall-stat .rank", text: "2,190 - Top0.1%")
+          end
+        end
+
+        it "試合数が表示される事" do
+          within ".overall-record-area" do
+            expect(page).to have_selector(".overall-stat .name", text: "Matchesplayed")
+            expect(page).to have_selector(".overall-stat .value", text: "8,916")
+            expect(page).to have_selector(".overall-stat .rank", text: "--- - Top0.7%")
+          end
+        end
+
+        it "勝利数が表示される事" do
+          within ".overall-record-area" do
+            expect(page).to have_selector(".overall-stat .name", text: "Wins")
+            expect(page).to have_selector(".overall-stat .value", text: "1,599")
+            expect(page).to have_selector(".overall-stat .rank", text: "4,285 - Top0.4%")
+          end
+        end
+
+        it "キルリーダーとしてのキル数が表示される事" do
+          within ".overall-record-area" do
+            expect(page).to have_selector(".overall-stat .name", text: "Killsaskillleader")
+            expect(page).to have_selector(".overall-stat .value", text: "3,383")
+            expect(page).to have_selector(".overall-stat .rank", text: "--- - Top0.1%")
+          end
+        end
+
+        it "シーズンキル数が表示される事" do
+          within ".overall-record-area" do
+            expect(page).to have_selector(".overall-stat .name", text: "Season10キル数")
+            expect(page).to have_selector(".overall-stat .value", text: "4,122")
+            expect(page).to have_selector(".overall-stat .rank", text: "--- - Top0.9%")
+          end
+        end
+
+        it "シーズン勝利数が表示される事" do
+          within ".overall-record-area" do
+            expect(page).to have_selector(".overall-stat .name", text: "Season10勝利数")
+            expect(page).to have_selector(".overall-stat .value", text: "---")
+            expect(page).to have_selector(".overall-stat .rank", text: "--- - Top---")
+          end
+        end
+
+        it "1試合での平均キル数が表示される事" do
+          within ".overall-record-area" do
+            expect(page).to have_selector(".overall-stat", text: "1試合での平均キル数")
+            expect(page).to have_selector(".overall-stat .value", text: "5.08")
+          end
+        end
+
+        it "勝率が表示される事" do
+          within ".overall-record-area" do
+            expect(page).to have_selector(".overall-stat .name", text: "勝率")
+            expect(page).to have_selector(".overall-stat .value", text: "17.9%")
+          end
+        end
+
+        it "現在のランクが表示される事" do
+          within ".overall-record-area" do
+            expect(page).to have_selector(".overall-stat .name", text: "現在のランク")
+            expect(page).to have_selector(".overall-stat .value img, img[src$='master.png']")
+            expect(page).to have_selector(".overall-stat .value", text: "Master")
+            expect(page).to have_selector(".overall-stat .rank", text: "1,008 - Top0.2%")
+          end
+        end
+      end
+
+      context "レジェンドステータス" do
+        it "取得したレジェンドの数だけカードが表示される事" do
+          within ".trn-legend-stats-area" do
+            expect(page.all(".legend-stats-card").count).to eq 2
+          end
+        end
+
+        it "アイコンが表示されている事" do
+          within ".trn-legend-stats-area" do
+            expect(page).to have_selector(".legend-icon img, img[src$='Wraith_icon.jpg']")
+          end
+        end
+
+        it "レジェンド名が表示されている事" do
+          within ".trn-legend-stats-area" do
+            expect(page).to have_selector(".legend-name", text: "Wraith")
+          end
+        end
+
+        it "キル数が表示されている事" do
+          within ".trn-legend-stats-area" do
+            expect(page).to have_selector(".legend-stat .name", text: "Kills")
+            expect(page).to have_selector(".legend-stat .value", text: "23,996")
+            expect(page).to have_selector(".legend-stat .rank", text: "2,433 - Top1.0%")
+          end
+        end
+
+        it "ダメージ数が表示されている事" do
+          within ".trn-legend-stats-area" do
+            expect(page).to have_selector(".legend-stat .name", text: "Damage")
+            expect(page).to have_selector(".legend-stat .value", text: "7,025,561")
+            expect(page).to have_selector(".legend-stat .rank", text: "2,000 - Top0.0%")
+          end
+        end
+
+        it "勝利数が表示されている事" do
+          within ".trn-legend-stats-area" do
+            expect(page).to have_selector(".legend-stat .name", text: "Wins")
+            expect(page).to have_selector(".legend-stat .value", text: "894")
+            expect(page).to have_selector(".legend-stat .rank", text: "--- - Top1.0%")
+          end
+        end
+
+        it "試合数が表示されている事" do
+          within ".trn-legend-stats-area" do
+            expect(page).to have_selector(".legend-stat .name", text: "Matchesplayed")
+            expect(page).to have_selector(".legend-stat .value", text: "7,751")
+            expect(page).to have_selector(".legend-stat .rank", text: "--- - Top0.5%")
+          end
+        end
+
+        it "キルリーダーとしてのキル数が表示されている事" do
+          within ".trn-legend-stats-area" do
+            expect(page).to have_selector(".legend-stat .name", text: "Killsaskillleader")
+            expect(page).to have_selector(".legend-stat .value", text: "965")
+            expect(page).to have_selector(".legend-stat .rank", text: "--- - Top8.1%")
+          end
+        end
       end
     end
 
@@ -32,7 +225,7 @@ RSpec.describe TrackerApiService, type: :system do
       it "戦績が取得できない事" do
         no_game_account_info
         visit user_path(user.id)
-        expect(page).to have_selector(".trn-failed-stats-container h2, 戦績を取得できませんでした")
+        expect(page).to have_selector(".trn-failed-stats-container h2", text: "戦績を取得できませんでした")
       end
     end
 


### PR DESCRIPTION
## 実装内容
- パンくずリストが表示されているかについてのシステムスペックを実装
- お問い合わせページのシステムスペックを実装
- GameAccountInfoのバリデーションテストをモデルスペックで実装
- TrackerApiServiceモデルでAPI通信をした時の返り値のテストを実装
- TrackerMatchRecordモデルでAPI通信をした時の返り値のテストを実装
- ユーザーページの総合戦績の表示テストをTrackerApiServiceのシステムスペックで実装
- requests/user_spec.rbでAPI通信をモックに変更