### PR TITLE
Fix:必要なカラムの追加と不要なカラムの削除

### DIFF
--- a/db/migrate/20231110024226_add_last_accessed_at_match_record_from_users.rb
+++ b/db/migrate/20231110024226_add_last_accessed_at_match_record_from_users.rb
@@ -1,0 +1,5 @@
+class AddLastAccessedAtMatchRecordFromUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :last_accessed_at_match_record, :datetime
+  end
+end

--- a/db/migrate/20231110031431_remove_last_accessed_at_from_users.rb
+++ b/db/migrate/20231110031431_remove_last_accessed_at_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveLastAccessedAtFromUsers < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :users, :last_accessed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_03_023717) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_10_031431) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.integer "record_id", null: false
-    t.integer "blob_id", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -34,7 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_03_023717) do
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.integer "blob_id", null: false
+    t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
@@ -85,7 +85,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_03_023717) do
     t.datetime "updated_at", null: false
     t.text "self_introduction"
     t.datetime "last_accessed_at_match_record"
-    t.string "profile"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## 実装内容
- Userテーブルに試合履歴取得時間を保存するlast_accessed_at_match_recordを追加
- Userテーブルのlast_accessed_atを削除
- ローカル環境でrails db:migrate:resetを実行しschema.rbを整理