### PR TITLE
Update: ゲストアカウントの判別方法を変更

### DIFF
--- a/app/controllers/game_account_info_controller.rb
+++ b/app/controllers/game_account_info_controller.rb
@@ -2,7 +2,7 @@ class GameAccountInfoController < ApplicationController
   before_action :authenticate_user!
 
   def edit
-    if current_user.id == 1
+    if current_user.email == "guest@example.com"
       redirect_to user_path(current_user.id), alert: "ゲストアカウントにはゲームアカウントを登録できません。"
     else
       @game_account_info = GameAccountInfo.find_or_initialize_by(user_id: current_user.id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,7 @@ class User < ApplicationRecord
   def self.guest
     find_or_create_by!(email: 'guest@example.com') do |user|
       user.name = "ゲストアカウント"
+      user.self_introduction = "ゲストアカウントです。このアカウントにゲームアカウントの登録はできません。"
       user.password = SecureRandom.urlsafe_base64
       user.password_confirmation = user.password
     end

--- a/app/views/tracker_match_records/index.html.erb
+++ b/app/views/tracker_match_records/index.html.erb
@@ -16,7 +16,7 @@
       <p>試合履歴</p>
     </div>
   </div>
-  <% if @user.id == 1 %>
+  <% if @user.email == "guest@example.com" %>
     <%= render "shared/guest_account" %>
   <% elsif @match_histories == "Apilimit" %>
     <%= render "shared/api_rate_limit" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -16,7 +16,7 @@
       <%= link_to "試合履歴", user_tracker_match_records_path(@user.id) %>
     </div>
   </div>
-  <% if @user.id == 1 %>
+  <% if @user.email == "guest@example.com" %>
     <%= render "shared/guest_account" %>
   <% elsif @trn_player_stats == "Apilimit" %>
     <%= render "shared/api_rate_limit" %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,0 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
-#   Character.create(name: "Luke", movie: movies.first)

--- a/spec/system/tracker_match_records_spec.rb
+++ b/spec/system/tracker_match_records_spec.rb
@@ -44,6 +44,14 @@ RSpec.describe TrackerMatchRecord, type: :system do
       sign_in user
     end
 
+    describe "ゲストアカウントの試合履歴ページを表示した時" do
+      it "試合履歴が表示されない事" do
+        sign_in guest_user
+        visit user_tracker_match_records_path(guest_user.id)
+        expect(page).to have_content "ゲストアカウントでは戦績は表示できません。"
+      end
+    end
+
     describe "ゲームアカウントが存在する時" do
       before do
         steam_game_account_info

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -317,9 +317,12 @@ RSpec.describe Users, type: :system do
     end
 
     describe "プロフィール編集" do
+      before do
+        visit edit_user_registration_path
+      end
+
       context "アイコン画像をアップロードする時" do
         it "正常にアップロードでき、表示される事" do
-          visit edit_user_registration_path
           attach_file "user[avatar]", Rails.root.join('spec/fixtures/image/test_avatar.jpg').to_s
           fill_in "現在のパスワード", with: user.password
           click_button "更新する"
@@ -329,7 +332,6 @@ RSpec.describe Users, type: :system do
       end
       context "アイコン画像をアップロードしない時" do
         it "デフォルト画像が表示される事" do
-          visit edit_user_registration_path
           fill_in "現在のパスワード", with: user.password
           click_button "更新する"
           expect(page).to have_content "アカウント情報を変更しました。"
@@ -338,7 +340,6 @@ RSpec.describe Users, type: :system do
       end
       context "フォームの入力値が正常" do
         it "プロフィールの編集が成功する事" do
-          visit edit_user_registration_path
           fill_in "ユーザー名", with: "Updateテストユーザー"
           fill_in "プロフィール", with: "テストユーザーです。"
           fill_in "Eメール", with: "Update_test@example.com"
@@ -350,7 +351,6 @@ RSpec.describe Users, type: :system do
       end
       context "ユーザー名が未入力の時" do
         it "プロフィールの編集が失敗する事" do
-          visit edit_user_registration_path
           fill_in "ユーザー名", with: ""
           fill_in "プロフィール", with: "テストユーザーです。"
           fill_in "Eメール", with: user.email
@@ -363,7 +363,6 @@ RSpec.describe Users, type: :system do
       context "登録済みのメールアドレスが入力された時" do
         it "プロフィールの編集が失敗する事" do
           registered_user
-          visit edit_user_registration_path
           fill_in "ユーザー名", with: user.name
           fill_in "プロフィール", with: "テストユーザーです。"
           fill_in "Eメール", with: registered_user.email
@@ -375,7 +374,6 @@ RSpec.describe Users, type: :system do
       end
       context "現在のパスワードが未入力の時" do
         it "プロフィールの編集が失敗する事" do
-          visit edit_user_registration_path
           fill_in "ユーザー名", with: user.name
           fill_in "プロフィール", with: "テストユーザーです。"
           fill_in "Eメール", with: user.email
@@ -387,7 +385,6 @@ RSpec.describe Users, type: :system do
       end
       context "現在のパスワードが間違っている時" do
         it "プロフィールの編集が失敗する事" do
-          visit edit_user_registration_path
           fill_in "ユーザー名", with: user.name
           fill_in "プロフィール", with: "テストユーザーです。"
           fill_in "Eメール", with: user.email
@@ -395,6 +392,28 @@ RSpec.describe Users, type: :system do
           click_button "更新する"
           expect(page).to have_content "現在のパスワードが一致しません"
           expect(current_path).to eq edit_user_registration_path
+        end
+      end
+    end
+  end
+
+  describe "ゲストアカウントでログインしている時" do
+    before do
+      guest_user
+      user
+      sign_in guest_user
+    end
+    describe "プロフィール編集" do
+      context "プロフィールを編集する時" do
+        it "プロフィールの編集が失敗する事" do
+          visit edit_user_registration_path
+          fill_in "ユーザー名", with: "ゲスト"
+          fill_in "プロフィール", with: guest_user.self_introduction
+          fill_in "Eメール", with: guest_user.email
+          fill_in "現在のパスワード", with: guest_user.password
+          click_button "更新する"
+          expect(page).to have_content "ゲストユーザーの更新・削除はできません。"
+          expect(current_path).to eq user_path(guest_user.id)
         end
       end
     end


### PR DESCRIPTION
## 実装内容
- 部分テンプレートやゲームアカウント登録時などのゲストアカウント判別方法をuser.idからuser.emailに変更
- ゲストアカウントに関するRspecの実装