### PR TITLE
Update:先月と今月の総キル数表示機能の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,39 @@
 # README
 
-## アプリURL
-以下のURLから実際にサービスを利用することができます。テストデータも用意しており、アカウント登録せずともアプリの機能を試すことができます。  
+## アプリ URL
+
+以下の URL から実際にサービスを利用することができます。テストデータも用意しており、アカウント登録せずともアプリの機能を試すことができます。  
 https://apexlegends-status-b4441d272292.herokuapp.com
 
 ## アプリケーションを開発した経緯
-ApexLegendsの戦績を確認できるサイトとして[Tracker Network](https://tracker.gg/ "Tracker Network")がありますが。このアプリでは総キル数やレジェンドごとのキル数などの戦績に加え、カレンダーに1日の総キル数を表示し、1日に何キルしたかを確認しやすく
+
+ApexLegends の戦績を確認できるサービスとして[Tracker Network](https://tracker.gg/ "Tracker Network")が広く利用されています。私もその一人でしたが、このサイトでは 1 日の合計キル数などのキル数の推移を簡単に見ることができないという点を不便に感じていました。  
+今回開発したサービスでは、総キル数やレジェンドごとのキル数など、一般的な戦績表示機能に加え、独自機能として試合履歴を日別で保存する機能を追加しました。  
+この機能の目的は、ユーザーが自身の目標を達成するための支援です。例えば、「1 ヶ月でこれだけキル数を増やしたい！」などの目標を掲げるユーザーにとって、サービスを通じて目標を計画的に達成できるよう支援することを目指しています。
 
 ## 主なページと機能
 
 ## 使用技術
+
 ### バックエンド
+
 - Ruby 3.1.2
 - Rails 7.0.7
+
 ### フロントエンド
+
 - HTML
 - CSS (SCSS)
 - Bootstrap ([Startbootstrap](https://startbootstrap.com/template/scrolling-nav "Start Bootstrap"))
 - JavaScript（jQuery）
+
 ### インフラストラクチャ
+
 - AWS S3
-## ER図
+
+### API
+
+- [Tracker Network API](https://tracker.gg/ "Tracker Network API")
+  - Apex Legends の戦績データを取得するために使用しています。戦績関連の情報を取得し当サービスでの表示・保存に活用しています。
+
+## ER 図

--- a/README.md
+++ b/README.md
@@ -1,24 +1,23 @@
 # README
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+## アプリURL
+以下のURLから実際にサービスを利用することができます。テストデータも用意しており、アカウント登録せずともアプリの機能を試すことができます。  
+https://apexlegends-status-b4441d272292.herokuapp.com
 
-Things you may want to cover:
+## アプリケーションを開発した経緯
+ApexLegendsの戦績を確認できるサイトとして[Tracker Network](https://tracker.gg/ "Tracker Network")がありますが。このアプリでは総キル数やレジェンドごとのキル数などの戦績に加え、カレンダーに1日の総キル数を表示し、1日に何キルしたかを確認しやすく
 
-* Ruby version
+## 主なページと機能
 
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+## 使用技術
+### バックエンド
+- Ruby 3.1.2
+- Rails 7.0.7
+### フロントエンド
+- HTML
+- CSS (SCSS)
+- Bootstrap ([Startbootstrap](https://startbootstrap.com/template/scrolling-nav "Start Bootstrap"))
+- JavaScript（jQuery）
+### インフラストラクチャ
+- AWS S3
+## ER図

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12550,6 +12550,18 @@ footer {
   }
 }
 
+.compare-kills {
+  display: flex;
+  justify-content: space-around;
+  color: #ffffff;
+}
+
+.compare-kills p {
+  font-size: 1.5rem;
+  margin: 0 auto;
+  margin-bottom: 0.5rem;
+}
+
 .simple-calendar {
   table,
   th,

--- a/app/helpers/tracker_match_records_helper.rb
+++ b/app/helpers/tracker_match_records_helper.rb
@@ -19,4 +19,21 @@ module TrackerMatchRecordsHelper
   def match_results(matches, date)
     matches.where(match_date: date.all_day)
   end
+
+  def month_kills(user, start_date)
+    start_date = Date.new(start_date.year, start_date.month, 1)
+    end_date =  start_date.end_of_month
+    calculate_kills(user, start_date, end_date)
+  end
+
+  def previous_month_kills(user, start_date)
+    start_date = Date.new(start_date.year, start_date.month - 1, 1)
+    end_date =  start_date.end_of_month
+    calculate_kills(user, start_date, end_date)
+  end
+
+  def calculate_kills(user, start_date, end_date)
+    month_matches = TrackerMatchRecord.where(user_id: user.id, match_date: start_date..end_date)
+    month_matches.all.sum(:kills)
+  end
 end

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -1,4 +1,8 @@
 <div class="simple-calendar">
+  <div class="compare-kills">
+    <p>今月の総キル数：<%= month_kills(@user, start_date) %>キル</p>
+    <p>先月の総キル数：<%= previous_month_kills(@user, start_date) %>キル</p>
+  </div>
   <div class="calendar-heading">
     <% unless start_date.month == Time.current.month - 2 %>
       <%= link_to t("simple_calendar.previous", default: "先月"), calendar.url_for_previous_view %>

--- a/app/views/tracker_match_records/_match_history.html.erb
+++ b/app/views/tracker_match_records/_match_history.html.erb
@@ -1,7 +1,7 @@
 <div class="match-record-calendar-area">
   <div class="match-record-calendar-container bg-gray">
     <div class="match-record-calendar-title">
-      <h2>今月のキル数一覧</h2>
+      <h2>キル数一覧</h2>
     </div>
     <div class="match-record-calendar">
       <%= month_calendar do |date| %>

--- a/app/views/tracker_match_records/_match_history.html.erb
+++ b/app/views/tracker_match_records/_match_history.html.erb
@@ -7,7 +7,7 @@
       <%= month_calendar do |date| %>
         <%= button_to user_tracker_show_records_path, {params: {match_date: date, match_ids: match_id(matches, date)} , remote: true} do %>
           <p><%= date.day %></p>
-          <p><%= match_kills(@matches, date) %>kills</p>
+          <p><%= match_kills(matches, date) %>kills</p>
         <% end %>
       <% end %>
     </div>


### PR DESCRIPTION
## 実装目的
- 先月と今月の合計キル数を表示する事で、今月のキル数の確認、先月との比較がし易くなる
## 実装内容
- 試合履歴表示ページに表示している月の総キル数と先月の総キル数を表示