### PR TITLE
Update: ゲームアカウント編集時、試合履歴を削除するよう実装

### DIFF
--- a/app/controllers/game_account_info_controller.rb
+++ b/app/controllers/game_account_info_controller.rb
@@ -12,11 +12,18 @@ class GameAccountInfoController < ApplicationController
   def update
     @game_account_info = GameAccountInfo.find_or_initialize_by(user_id: current_user.id)
     if @game_account_info.update(game_account_info_params)
+      delete_match_record
       flash[:notice] = I18n.t('flash.update')
       redirect_to user_path
     else
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def delete_match_record
+    user = @game_account_info.user
+    records = user.tracker_match_records.all
+    records.destroy_all
   end
 
   private

--- a/app/controllers/game_account_info_controller.rb
+++ b/app/controllers/game_account_info_controller.rb
@@ -11,19 +11,25 @@ class GameAccountInfoController < ApplicationController
 
   def update
     @game_account_info = GameAccountInfo.find_or_initialize_by(user_id: current_user.id)
-    if @game_account_info.update(game_account_info_params)
+    if account_match_check
+      redirect_to user_path
+    else
+      @game_account_info.update(game_account_info_params)
       delete_match_record
       flash[:notice] = I18n.t('flash.update')
       redirect_to user_path
-    else
-      render :edit, status: :unprocessable_entity
     end
+  end
+
+  def account_match_check
+    @game_account_info.platform == game_account_info_params[:platform] && @game_account_info.gameid == game_account_info_params[:gameid]
   end
 
   def delete_match_record
     user = @game_account_info.user
     records = user.tracker_match_records.all
     records.destroy_all
+    user.update(last_accessed_at_match_record: nil)
   end
 
   private

--- a/app/controllers/game_account_info_controller.rb
+++ b/app/controllers/game_account_info_controller.rb
@@ -14,10 +14,13 @@ class GameAccountInfoController < ApplicationController
     if account_match_check
       redirect_to user_path
     else
-      @game_account_info.update(game_account_info_params)
-      delete_match_record
-      flash[:notice] = I18n.t('flash.update')
-      redirect_to user_path
+      if @game_account_info.update(game_account_info_params)
+        delete_match_record
+        flash[:notice] = I18n.t('flash.update')
+        redirect_to user_path
+      else
+        render :edit, status: :unprocessable_entity
+      end
     end
   end
 

--- a/app/controllers/game_account_info_controller.rb
+++ b/app/controllers/game_account_info_controller.rb
@@ -13,14 +13,12 @@ class GameAccountInfoController < ApplicationController
     @game_account_info = GameAccountInfo.find_or_initialize_by(user_id: current_user.id)
     if account_match_check
       redirect_to user_path
+    elsif @game_account_info.update(game_account_info_params)
+      delete_match_record
+      flash[:notice] = I18n.t('flash.update')
+      redirect_to user_path
     else
-      if @game_account_info.update(game_account_info_params)
-        delete_match_record
-        flash[:notice] = I18n.t('flash.update')
-        redirect_to user_path
-      else
-        render :edit, status: :unprocessable_entity
-      end
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/spec/requests/game_account_infos_spec.rb
+++ b/spec/requests/game_account_infos_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "GameAccountInfos", type: :request do
     before do
       guest_user
       user
-      user.last_accessed_at_match_record = Date.today
+      user.last_accessed_at_match_record = Time.zone.today
       sign_in user
     end
 

--- a/spec/requests/game_account_infos_spec.rb
+++ b/spec/requests/game_account_infos_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe "GameAccountInfos", type: :request do
   let(:user) { FactoryBot.create(:user) }
   let(:guest_user) { FactoryBot.create(:guest_user) }
   let(:game_account_info) { FactoryBot.build(:game_account_info, user:) }
+  let(:tracker_match_record) { FactoryBot.create(:tracker_match_record, user:) }
 
   describe "GET/edit_game_account_info" do
     before do
@@ -62,12 +63,28 @@ RSpec.describe "GameAccountInfos", type: :request do
     before do
       guest_user
       user
+      user.last_accessed_at_match_record = Date.today
       sign_in user
-      patch game_account_info_path(user), params: { game_account_info: { platform: "origin", gameid: "Test" } }
     end
 
-    it "ゲームアカウントが更新された場合、マイページにリダイレクトされる事" do
-      expect(response).to redirect_to(user_path(user))
+    context "ゲームアカウントが変更された時" do
+      before do
+        tracker_match_record
+        patch game_account_info_path(user), params: { game_account_info: { platform: "origin", gameid: "Test" } }
+      end
+
+      it "試合履歴が削除される事" do
+        expect(user.tracker_match_records).to be_empty
+      end
+
+      it "ユーザーのlast_accessed_at_match_recordがnilになる事" do
+        user.reload
+        expect(user.last_accessed_at_match_record).to be_nil
+      end
+
+      it "マイページにリダイレクトされる事" do
+        expect(response).to redirect_to(user_path(user))
+      end
     end
   end
 end


### PR DESCRIPTION
## 実装目的
- ゲームアカウントを編集した際、試合履歴のデータが変更前のデータと変更後のデータが統合されるため
## 実装内容
- ゲームアカウント編集時、以前の試合履歴が削除されるよう実装。
- ゲームアカウント編集後、変更後のアカウントで試合履歴が取得できるようUserカラムのlast_accessed_at_match_recordカラムをnilにするよう実装
- 試合履歴の削除に関するRspecの実装