### PR TITLE
ユーザー一覧とユーザー検索のN+1問題を解決

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   before_action :set_q, :search
 
   def search
-    @users_result = @q.result
+    @users_result = @q.result.includes(:game_account_info, avatar_attachment: :blob)
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@ class UsersController < ApplicationController
   PERCENTAGE_BASE = 100
 
   def index
-    @users = User.all
+    @users = User.includes(:game_account_info, avatar_attachment: :blob)
   end
 
   def show


### PR DESCRIPTION
## 実装内容
- ユーザー一覧とユーザー検索時に、game_account_infoとavatarにアクセスするクエリがユーザー数分作成されていたため、事前に読み込むよう変更